### PR TITLE
Fix quotation errors in java doc

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/avro/sourcemapper/AvroSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/avro/sourcemapper/AvroSourceMapper.java
@@ -74,8 +74,8 @@ import java.util.List;
         examples = {
                 @Example(
                         syntax = "@source(type='inMemory', topic='user', @map(type='avro', schema .def = \"\"\"" +
-                                "{\"type\":\"record\",\"name\":“userInfo\",\"namespace\":\"user.example\",\"fields\":" +
-                                "[{\"name\":\"name\",\"type\":“string”}, {\"name\":\"age\", \"type\":\"int\"}]}" +
+                                "{\"type\":\"record\",\"name\":\"userInfo\",\"namespace\":\"user.example\",\"fields\":" +
+                                "[{\"name\":\"name\",\"type\":\"string”}, {\"name\":\"age\",\"type\":\"int\"}]}" +
                                 "\"\"\"))\n"
                                 + "define stream userStream (name string, age int );\n",
                         description = "Above configuration will do a default Avro input mapping. " +


### PR DESCRIPTION
## Purpose
> Fix errors in java doc. 

## Goals
> Generate the java documentation correctly.

## Approach
> put correct quotation marks.